### PR TITLE
Added params to storageProvider.GetActiveTriggers call

### DIFF
--- a/source/Jobbr.Server/Storage/JobbrRepository.cs
+++ b/source/Jobbr.Server/Storage/JobbrRepository.cs
@@ -94,7 +94,7 @@ namespace Jobbr.Server.Storage
         {
             try
             {
-                return this.storageProvider.GetActiveTriggers();
+                return this.storageProvider.GetActiveTriggers(page, pageSize, jobTypeFilter, jobUniqueNameFilter, query, sort);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
The paramters have been handed over to the repo but the repo didn't pass it to the storage provider