### PR TITLE
Feature/soft delete non existing jobs on startup

### DIFF
--- a/source/Jobbr.Server/JobRegistry/RegistryBuilder.cs
+++ b/source/Jobbr.Server/JobRegistry/RegistryBuilder.cs
@@ -268,6 +268,7 @@ namespace Jobbr.Server.JobRegistry
                 var jobRuns = storage.GetJobRunsByTriggerId(orphanedTrigger.JobId, orphanedTrigger.Id, pageSize: int.MaxValue).Items;
                 foreach (var jobRunToOmit in jobRuns)
                 {
+                    jobRunToOmit.Deleted = true;
                     jobRunToOmit.State = JobRunStates.Omitted;
                     storage.Update(jobRunToOmit);
                     numberOfChanges++;

--- a/source/Jobbr.Server/JobRegistry/RegistryBuilder.cs
+++ b/source/Jobbr.Server/JobRegistry/RegistryBuilder.cs
@@ -209,6 +209,7 @@ namespace Jobbr.Server.JobRegistry
             var numberOfChanges = 0;
             foreach (var jobRun in storage.GetJobRunsByJobId((int)undefinedJob.Id, pageSize: int.MaxValue).Items)
             {
+                jobRun.Deleted = true;
                 jobRun.State = JobRunStates.Omitted;
                 storage.Update(jobRun);
                 numberOfChanges++;

--- a/source/Jobbr.Server/JobRegistry/RegistryBuilder.cs
+++ b/source/Jobbr.Server/JobRegistry/RegistryBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Jobbr.ComponentModel.JobStorage;
 using Jobbr.ComponentModel.JobStorage.Model;

--- a/source/Jobbr.Server/JobRegistry/TriggerExtensions.cs
+++ b/source/Jobbr.Server/JobRegistry/TriggerExtensions.cs
@@ -32,13 +32,11 @@ namespace Jobbr.Server.JobRegistry
 
         private static bool IsSame(JobTriggerBase left, JobTriggerBase right)
         {
-            var jobIdEqual = left.JobId == right.JobId;
-
             var parametersEqual = string.Equals(left.Parameters, right.Parameters, StringComparison.OrdinalIgnoreCase);
             var userDisplayNameEqual = string.Equals(left.UserDisplayName, right.UserDisplayName, StringComparison.OrdinalIgnoreCase);
             var userIdEqual = string.Equals(left.UserId, right.UserId, StringComparison.OrdinalIgnoreCase);
 
-            var baseEqual = jobIdEqual && parametersEqual && userDisplayNameEqual && userIdEqual;
+            var baseEqual = parametersEqual && userDisplayNameEqual && userIdEqual;
             if (!baseEqual)
             {
                 return false;

--- a/source/Jobbr.Server/JobbrServer.cs
+++ b/source/Jobbr.Server/JobbrServer.cs
@@ -248,7 +248,7 @@ namespace Jobbr.Server
                 var numberOfChanges = this.registryBuilder.Apply(this.jobStorageProvider);
                 var numberOfJobs = this.jobStorageProvider.GetJobs(pageSize: int.MaxValue).Items.Count;
 
-                Logger.InfoFormat("There were {0} by the JobRegistry. There are now {1} known jobs right available.", numberOfChanges, numberOfJobs);
+                Logger.InfoFormat("There were {0} changes by the JobRegistry. There are now {1} known jobs right available.", numberOfChanges, numberOfJobs);
             }
             catch (Exception e)
             {

--- a/source/Jobbr.Tests/Registration/BuilderTests.cs
+++ b/source/Jobbr.Tests/Registration/BuilderTests.cs
@@ -167,7 +167,7 @@ namespace Jobbr.Tests.Registration
             builder.AddJobs(repo =>
                 repo.AsSingleSourceOfTruth().Define(jobName, "CLR.Type").WithTrigger("* * * * *"));
 
-            builder.Create().Start(Int32.MaxValue);
+            builder.Create().Start();
 
             Assert.IsTrue(toOmitJobRun.Deleted);
             Assert.AreEqual(JobRunStates.Omitted, toOmitJobRun.State);

--- a/source/Jobbr.Tests/Registration/BuilderTests.cs
+++ b/source/Jobbr.Tests/Registration/BuilderTests.cs
@@ -75,8 +75,9 @@ namespace Jobbr.Tests.Registration
 
             builder.Create().Start();
 
-            storage.Verify(s => s.DeleteJob(nonExistingJobId), Times.Once);
-            storage.Verify(s => s.DeleteTrigger(nonExistingJobId, nonExistingTriggerId), Times.Once);
+            Assert.IsTrue(nonExistingJob.Deleted);
+            Assert.IsFalse(triggerForNonExistingJob.IsActive);
+            Assert.IsTrue(triggerForNonExistingJob.Deleted);
         }
 
         [TestMethod]
@@ -99,7 +100,9 @@ namespace Jobbr.Tests.Registration
 
             builder.Create().Start();
 
-            storage.Verify(s => s.DeleteTrigger(1, 10), Times.Once);
+            Assert.IsFalse(job.Deleted);
+            Assert.IsFalse(toDeleteTrigger.IsActive);
+            Assert.IsTrue(toDeleteTrigger.Deleted);
         }
 
         private static PagedResult<T> CreatePagedResult<T>(params T[] args)
@@ -115,6 +118,9 @@ namespace Jobbr.Tests.Registration
                 .Returns(CreatePagedResult<JobRun>());
             storage.Setup(s => s.GetActiveTriggers(1, int.MaxValue, null, null, null))
                 .Returns(CreatePagedResult<JobTriggerBase>());
+            var anyId = It.IsAny<long>();
+            storage.Setup(s => s.GetJobRunsByJobId(It.IsAny<int>(), 1, int.MaxValue, false)).Returns(CreatePagedResult<JobRun>());
+            storage.Setup(s => s.GetJobRunsByTriggerId(anyId, anyId, 1, int.MaxValue, false)).Returns(CreatePagedResult<JobRun>());
         }
     }
 

--- a/source/Jobbr.Tests/Registration/TriggerExtensionsTests.cs
+++ b/source/Jobbr.Tests/Registration/TriggerExtensionsTests.cs
@@ -46,14 +46,13 @@ namespace Jobbr.Tests.Registration
         [TestMethod]
         public void TriggersAreEqual_WhenBaseInformationAreEqualEvenIdIsDifferent()
         {
-            const long jobId = 10;
             const string userDisplayName = "Jobbr";
             const string parameters = "json";
             const string userId = "1";
             var firstTrigger = new InstantTrigger
             {
                 Id = 1,
-                JobId = jobId,
+                JobId = 2,
                 Comment = "Different",
                 UserDisplayName = userDisplayName,
                 Parameters = parameters,
@@ -62,7 +61,7 @@ namespace Jobbr.Tests.Registration
             var secondTrigger = new InstantTrigger
             {
                 Id = 2,
-                JobId = jobId,
+                JobId = 4,
                 Comment = "Same same but different",
                 Parameters = parameters,
                 UserId = userId,
@@ -72,17 +71,6 @@ namespace Jobbr.Tests.Registration
             var isTriggerEqual = firstTrigger.IsTriggerEqual(secondTrigger);
 
             Assert.IsTrue(isTriggerEqual);
-        }
-
-        [TestMethod]
-        public void TriggersAreNotEqual_WhenJobIdIsDifferent()
-        {
-            var firstTrigger = new InstantTrigger { JobId = 1 };
-            var secondTrigger = new InstantTrigger { JobId = 3 };
-
-            var isTriggerEqual = firstTrigger.IsTriggerEqual(secondTrigger);
-
-            Assert.IsFalse(isTriggerEqual);
         }
 
         [TestMethod]


### PR DESCRIPTION
Implements the possibility to set the JobDefintions defined in the code as the single source of truth.
Every Job and trigger which could not be associated with a defined job will be soft deleted. 